### PR TITLE
Fix for removal of custom component in esphome 2025.xx and up

### DIFF
--- a/ESPHome/smartintercom-avc305.yaml
+++ b/ESPHome/smartintercom-avc305.yaml
@@ -168,7 +168,11 @@ api:
 # Возможность обновляться по воздуху
 ota:
   password: "12345678"
-  
+
+external_components: # fix for removal of custom component in esphome 2025.xx and up
+  - source: github://esphome/esphome@2024.12.4
+    components: [ custom, custom_component ]
+
 custom_component:
   - id: ftp_server
     lambda: 'return {new FTPSrv("","")};' # (Логин, Пароль). По умолчанию anonymous  

--- a/ESPHome/smartintercom-esp32.yaml
+++ b/ESPHome/smartintercom-esp32.yaml
@@ -132,10 +132,8 @@ ota:
   platform: esphome
   password: "12345678"
 
-external_components:
-  - source:
-      type: git
-      url: https://github.com/robertklep/esphome-custom-component
+external_components: # fix for removal of custom component in esphome 2025.xx and up
+  - source: github://esphome/esphome@2024.12.4
     components: [ custom, custom_component ]
     
 custom_component:

--- a/ESPHome/smartintercom-esp8266.yaml
+++ b/ESPHome/smartintercom-esp8266.yaml
@@ -134,6 +134,10 @@ api:
 ota:
   password: "12345678"
 
+external_components: # fix for removal of custom component in esphome 2025.xx and up
+  - source: github://esphome/esphome@2024.12.4
+    components: [ custom, custom_component ]
+
 custom_component:
   - id: ftp_server
     lambda: 'return {new FTPSrv("","")};' # (Логин, Пароль). По умолчанию anonymous  


### PR DESCRIPTION
Исправление custom_component для smartintercom-esp8266.yaml и smartintercom-avc305.yaml, а также улучшение для smartintercom-esp32.yaml.

Нет смысла ссылаться на сторонний репозиторий, когда этот компонент можно получить с официального репозитория ESPHome, ссылаясь на последний релиз, где custom_component не был еще удален.
Это выглядит безопаснее и надежнее.